### PR TITLE
Fix error CS0618 (Lombiq Technologies: NEST-608)

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <Authors>Antoine Griffard</Authors>
-    <RepositoryUrl>https://github.com/agriffard/TheBootstrapTheme.OrchardCore</RepositoryUrl>
-    <PackageProjectUrl>https://github.com/agriffard/TheBootstrapTheme.OrchardCore</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/agriffard/TheBootstrapTheme</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/agriffard/TheBootstrapTheme</PackageProjectUrl>
     <TargetFramework>net8.0</TargetFramework>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/TheBootstrapTheme/Views/Layout.cshtml
+++ b/src/TheBootstrapTheme/Views/Layout.cshtml
@@ -1,7 +1,7 @@
 @using OrchardCore.Entities
 @using OrchardCore.ContentManagement
 @{
-    var themeSettings = Site.As<ContentItem>("TheBootstrapThemeSettings");
+    var themeSettings = Site.GetOrCreate<ContentItem>("TheBootstrapThemeSettings");
     var head = themeSettings?.Content?.TheBootstrapThemeSettings?.Head?.Text ?? string.Empty;
     var foot = themeSettings?.Content?.TheBootstrapThemeSettings?.Foot?.Text ?? string.Empty;
     var bg = themeSettings?.Content?.TheBootstrapThemeSettings?.Background?.Text ?? "dark";

--- a/src/TheBootstrapTheme/Views/MenuItem.cshtml
+++ b/src/TheBootstrapTheme/Views/MenuItem.cshtml
@@ -6,7 +6,7 @@
 
     if ((bool)Model.HasItems)
     {
-        var themeSettings = Site.As<ContentItem>("TheBootstrapThemeSettings");
+        var themeSettings = Site.GetOrCreate<ContentItem>("TheBootstrapThemeSettings");
         var nav = themeSettings?.Content?.TheBootstrapThemeSettings?.Navigation.Text ?? string.Empty;
         tag.AddCssClass(nav != "FixedBottom" ? "dropdown" : "dropup");
     }


### PR DESCRIPTION
Fixes error CS0618: 'EntityExtensions.As<T>(IEntity, string)' is obsolete that prevented NuGet release.

I've also fixed the `<RepositoryUrl>` and `<PackageProjectUrl>` in the _Common.props_ that was pointing to the wrong URL and giving 404. Because of this, the links in NuGet were wrong previously.